### PR TITLE
Add POSTHOG_DB_NAME environment variable to Docker stack configuration

### DIFF
--- a/infrastructure/docker/docker-stack.yml
+++ b/infrastructure/docker/docker-stack.yml
@@ -158,6 +158,7 @@ services:
     environment:
       - POSTGRES_HOST=posthog_db
       - POSTGRES_DB=posthog
+      - POSTHOG_DB_NAME=posthog
       - POSTGRES_USER=posthog
       - POSTGRES_PASSWORD=${POSTHOG_DB_PASSWORD}
       - REDIS_URL=redis://posthog_redis:6379


### PR DESCRIPTION
- Introduced POSTHOG_DB_NAME variable in the docker-stack.yml to specify the database name for PostHog, enhancing configuration clarity and ensuring proper database connectivity.
- This change supports the ongoing integration of PostHog analytics within the TeamHub platform, aligning with recent updates to the Docker setup for improved service management.