### PR TITLE
Refactor ClickHouse configuration for simplified single-node setup

### DIFF
--- a/infrastructure/configs/clickhouse-config.xml
+++ b/infrastructure/configs/clickhouse-config.xml
@@ -36,31 +36,24 @@
         </default>
     </quotas>
 
-    <!-- Cluster configuration for PostHog -->
+    <!-- Cluster configuration for PostHog (simplified for single-node setup) -->
     <remote_servers>
-        <posthog_migrations>
-            <shard>
-                <replica>
-                    <host>clickhouse</host>
-                    <port>9000</port>
-                </replica>
-            </shard>
-        </posthog_migrations>
+        <!-- Empty for single-node setup -->
     </remote_servers>
 
-    <!-- Macros for distributed tables -->
+    <!-- Macros for distributed tables (simplified) -->
     <macros>
         <shard>01</shard>
         <replica>01</replica>
     </macros>
 
-    <!-- Zookeeper configuration (placeholder for future scaling) -->
-    <zookeeper>
+    <!-- Zookeeper configuration (commented out for single-node setup) -->
+    <!-- <zookeeper>
         <node>
             <host>zookeeper</host>
             <port>2181</port>
         </node>
-    </zookeeper>
+    </zookeeper> -->
 
     <!-- Storage configuration -->
     <storage_configuration>

--- a/infrastructure/docker/docker-stack.yml
+++ b/infrastructure/docker/docker-stack.yml
@@ -215,7 +215,6 @@ services:
       - CLICKHOUSE_DATABASE=posthog
       - CLICKHOUSE_USER=posthog
       - CLICKHOUSE_PASSWORD=${POSTHOG_CLICKHOUSE_PASSWORD}
-      - CLICKHOUSE_CLUSTER=posthog_migrations
       - CLICKHOUSE_REPLICATION=false
       - CLICKHOUSE_ASYNC_MIGRATIONS_OPT_OUT=true
       - REDIS_URL=redis://posthog_redis:6379


### PR DESCRIPTION
- Updated clickhouse-config.xml to simplify the cluster configuration for a single-node setup, removing unnecessary elements and comments.
- Adjusted docker-stack.yml to remove the ClickHouse cluster environment variable, streamlining the deployment configuration for improved clarity and management.