### PR TITLE
Update Docker stack configuration to include service dependencies

### DIFF
--- a/infrastructure/docker/docker-stack.yml
+++ b/infrastructure/docker/docker-stack.yml
@@ -50,6 +50,11 @@ services:
       teamhub_network:
         aliases:
           - nginx
+    depends_on:
+      - teamhub
+      - posthog
+      - nextcloud
+      - remotion
 
   # Remotion rendering service
   remotion:


### PR DESCRIPTION
- Added 'depends_on' for teamhub, posthog, nextcloud, and remotion services in docker-stack.yml to ensure proper service initialization order during deployment.
- This change enhances the reliability of the Docker setup by ensuring that dependent services are fully operational before starting the main application services.