### PR TITLE
Add force redeploy option for ClickHouse in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,14 @@ on:
         options:
           - 'false'
           - 'true'
+      force_redeploy_clickhouse:
+        description: 'Force redeploy ClickHouse service (for PostHog)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
       force_redeploy_pinggy:
         description: 'Force redeploy Pinggy tunnel'
         required: false
@@ -186,6 +194,7 @@ jobs:
           echo "  🔧 Infrastructure: ${{ github.event.inputs.force_redeploy_infrastructure || 'false' }} (rebuilds DB image)"
           echo "  ☁️ Nextcloud:      ${{ github.event.inputs.force_redeploy_nextcloud || 'false' }}"
           echo "  📊 PostHog:        ${{ github.event.inputs.force_redeploy_posthog || 'false' }}"
+          echo "  🗄️  ClickHouse:     ${{ github.event.inputs.force_redeploy_clickhouse || 'false' }}"
           echo "  🚇 Pinggy:         ${{ github.event.inputs.force_redeploy_pinggy || 'false' }}"
 
       - name: Setup Pinggy tunnel
@@ -249,6 +258,7 @@ jobs:
           export FORCE_REDEPLOY_NEXTCLOUD="${{ github.event.inputs.force_redeploy_nextcloud || 'false' }}"
           export FORCE_REDEPLOY_POSTHOG="${{ github.event.inputs.force_redeploy_posthog || 'false' }}"
           export FORCE_REDEPLOY_PINGGY="${{ github.event.inputs.force_redeploy_pinggy || 'false' }}"
+          export FORCE_REDEPLOY_CLICKHOUSE="${{ github.event.inputs.force_redeploy_clickhouse || 'false' }}"
 
           infrastructure/scripts/deploy.sh ${{ needs.build-and-push.outputs.tag }}
 

--- a/infrastructure/scripts/deploy.sh
+++ b/infrastructure/scripts/deploy.sh
@@ -320,6 +320,8 @@ check_individual_service_status() {
 
     if [ "$FORCE_REDEPLOY_POSTHOG" = "true" ] || [ "$POSTHOG_OK" = false ]; then
         NEEDS_DEPLOYMENT=true
+        # When PostHog is redeployed, also redeploy ClickHouse
+        export FORCE_REDEPLOY_CLICKHOUSE="true"
     fi
 
     if [ "$FORCE_REDEPLOY_CLICKHOUSE" = "true" ] || [ "$CLICKHOUSE_OK" = false ]; then


### PR DESCRIPTION
- Introduced `force_redeploy_clickhouse` option in the GitHub Actions deployment workflow to allow for manual redeployment of the ClickHouse service specifically for PostHog.
- This addition enhances deployment flexibility and control, enabling users to trigger redeployments as needed without altering the default behavior.