### PR TITLE
Update PostHog service configuration in Docker stack

### DIFF
--- a/infrastructure/docker/docker-stack.yml
+++ b/infrastructure/docker/docker-stack.yml
@@ -220,7 +220,7 @@ services:
 
   # PostHog Analytics Platform
   posthog:
-    image: posthog/posthog:release-1.215.2
+    image: posthog/posthog:latest
     deploy:
       replicas: 1
       placement:
@@ -274,7 +274,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 300s
 
   # PostHog PostgreSQL Database
   posthog_db:


### PR DESCRIPTION
- Changed the PostHog image from 'release-1.215.2' to 'latest' to ensure the use of the most recent features and fixes.
- Increased the start period for the PostHog service from 60s to 300s to allow for a more stable startup process, enhancing deployment reliability.