### PR TITLE
Update Dockerfile to build Agelum application instead of TeamHub

### DIFF
--- a/apps/teamhub/Dockerfile.distroless
+++ b/apps/teamhub/Dockerfile.distroless
@@ -35,7 +35,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.pnpm-store \
 COPY . .
 
 # Build the application (creates standalone output)
-RUN pnpm build:teamhub:prod
+RUN pnpm build:agelum:prod
 
 # ===============================
 # Production stage - Distroless (smallest possible)


### PR DESCRIPTION
- Changed the build command in the Dockerfile from `pnpm build:teamhub:prod` to `pnpm build:agelum:prod` to reflect the rebranding of the application.
- Ensured that the update aligns with the project's architectural guidelines and maintains consistency in the build process.